### PR TITLE
fix/setting menu close- pressing setting icon

### DIFF
--- a/medicare-proj/package-lock.json
+++ b/medicare-proj/package-lock.json
@@ -16,7 +16,8 @@
         "express": "^4.18.2",
         "mongodb": "^6.3.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-icons": "^5.0.1"
       },
       "devDependencies": {
         "@types/react": "^18.2.43",
@@ -4198,6 +4199,14 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/medicare-proj/package.json
+++ b/medicare-proj/package.json
@@ -18,7 +18,8 @@
     "express": "^4.18.2",
     "mongodb": "^6.3.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-icons": "^5.0.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",

--- a/medicare-proj/src/components/SideBars/SideBarLeft.jsx
+++ b/medicare-proj/src/components/SideBars/SideBarLeft.jsx
@@ -1,11 +1,12 @@
 import React, { useState } from "react";
 import "./SideBarLeft.css";
 import SettingsMenu from "../SettingsMenu"; // Import the SettingsMenu component
-
+import { IoClose } from "react-icons/io5";
 function SideBarLeft({ onSettingsIconClick, onHomeIconClick }) {
   const [showSettingsMenu, setShowSettingsMenu] = useState(false);
 
   const handleSettingsIconClick = () => {
+    // console.log("clicked")
     setShowSettingsMenu(!showSettingsMenu);
   };
 
@@ -18,10 +19,19 @@ function SideBarLeft({ onSettingsIconClick, onHomeIconClick }) {
         ></i>
       </nav>
       <nav className="settings-icon-container">
-        <i
-          onClick={handleSettingsIconClick}
+
+    
+      <div onClick={handleSettingsIconClick}>
+
+     
+        {
+          showSettingsMenu ?  <IoClose color="white" size={32} /> :   <i
+         
           className={`bi ${showSettingsMenu ? "bi-gear-fill" : "bi-gear"} settings-icon`}
         ></i>
+        }
+      </div>
+    
       </nav>
 
       {/* Conditionally render SettingsMenu based on showSettingsMenu state */}


### PR DESCRIPTION
Fix - #22 

I used react-icons. Setting menu will be closed  when user click on close icon.

Video :-


https://github.com/iamanishsrivastava/MediCare/assets/84280396/94b52440-574d-4c5b-85a5-fe0d2782bd11

